### PR TITLE
Use same subject for both mailto references

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,7 +483,7 @@ body::after{
                             <div class="control">
                                 <a class="button button-primary button-block button-shadow" href="mailto:info@f-online.at?subject=Werben auf F-Online&body=Bitte um Zusendung weitere Informationen bzw. Kontaktaufnahme.%0A%0AMit Freundlichen Grüßen" onclick="_paq.push(['trackEvent', 'click', 'bottom-email-button']);">Information per Email anfordern</a>
                             </div>
-							<p class="text-xs mt-16	 text-center">(oder einfach Email an <a href="mailto:info@f-online.at" onclick="_paq.push(['trackEvent', 'click', 'bottom-email-native']);">info@f-online.at</a>)</p>
+							<p class="text-xs mt-16	 text-center">(oder einfach Email an <a href="mailto:info@f-online.at?subject=Werben auf F-Online&body=Bitte um Zusendung weitere Informationen bzw. Kontaktaufnahme.%0A%0AMit Freundlichen Grüßen" onclick="_paq.push(['trackEvent', 'click', 'bottom-email-native']);">info@f-online.at</a>)</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
As both links use the same functionality, we can also set them both the same subject for more user comfort.